### PR TITLE
EndToEndGrpcTest(final)

### DIFF
--- a/test/EndToEndGrpcTest.java
+++ b/test/EndToEndGrpcTest.java
@@ -1,0 +1,115 @@
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Server;
+import io.grpc.ServerBuilder;
+import project.annotations.ComputeControllerAPI;
+import project.annotations.ComputeControllerAPIImplementation;
+import project.annotations.DataStoreComputeAPI;
+import project.annotations.DataStoreComputeAPIImplementation;
+import project.annotations.UserComputeAPI;
+import project.annotations.UserComputeAPIImplementation;
+import project.datastore.grpc.DataStoreGrpcService;
+import project.datastore.grpc.GrpcDataStoreComputeAPI;
+import project.usercompute.grpc.UserComputeGrpcService;
+import project.rpc.usercompute.UserComputeAPIGrpc;
+
+public class EndToEndGrpcTest {
+
+  @Test
+  public void testMemoryInputEndToEnd() throws Exception {
+    
+    // Creating servers on temporary ports(pot = 0).
+    Server dataStoreServer = null;
+    Server computeServer = null;
+    ManagedChannel dsChannel = null;
+    ManagedChannel computeChannel = null;
+    
+    try {
+      // Start datastore server over gRPC.
+      DataStoreComputeAPI storeImpl = new DataStoreComputeAPIImplementation();
+      // pick any available port
+      dataStoreServer = ServerBuilder.forPort(0).addService(new DataStoreGrpcService(storeImpl)).build().start();
+      
+      int dataStorePort = dataStoreServer.getPort();
+      System.out.println("Datastore test server started on port " + dataStorePort);
+      
+      // Create gRPC client adapter for dataqstore to be used by compute server.
+      dsChannel = ManagedChannelBuilder.forAddress("localhost", dataStorePort).usePlaintext().build();
+      
+      DataStoreComputeAPI storeClient = new GrpcDataStoreComputeAPI(dsChannel);
+      
+      // Wire compute server with compute and datastore over gRPC.
+      ComputeControllerAPI core = new ComputeControllerAPIImplementation();
+      UserComputeAPI userApi = new UserComputeAPIImplementation(storeClient, core);
+      
+      computeServer = ServerBuilder.forPort(0).addService(new UserComputeGrpcService(userApi)).build().start();
+      
+      int computePort = computeServer.getPort();
+      System.out.println("Compute test server started on port " + computePort);
+
+      // Create gRPC client stub to compute server.
+      computeChannel = ManagedChannelBuilder.forAddress("localhost", computePort).usePlaintext().build();    
+      
+      UserComputeAPIGrpc.UserComputeAPIBlockingStub stub =
+          UserComputeAPIGrpc.newBlockingStub(computeChannel);
+      
+      // Build UserSubmission using same fields as client.
+      project.rpc.usercompute.UserSubmission request = project.rpc.usercompute.UserSubmission.newBuilder()
+          .setInput(
+              project.rpc.usercompute.InputSource.newBuilder()
+                  .setInputType("memory")
+                  .setLocation("16")
+                  .build())
+          .setOutput(
+              project.rpc.usercompute.OutputSource.newBuilder()
+                  .setOutputType("stdout")
+                  .setLocation("") 
+                  .build())
+          .setDelimiters(
+              project.rpc.usercompute.Delimiter.newBuilder()
+                  .setComboDelimiter(",")
+                  .setResultDelimiter(":")
+                  .build())
+          .build();
+      
+      // Send request over gRPC and get response
+      project.rpc.usercompute.UserSubResponse response = stub.submit(request);
+      
+      System.out.println("EndToEndGrpcTest -> Status: " + response.getStatus()+ ", subId: " + response.getSubId());
+      
+      // Assertions to make sure pipeline succeeds.
+      assertEquals(project.rpc.usercompute.SubmissionStatus.SUB_STATUS_SUCCESS, response.getStatus(), "End-to-end gRPC submission succeeds.");
+      
+      assertNotNull(response.getSubId(), "Submission ID shouldn't be null.");
+      assertFalse(response.getSubId().isBlank(), "Submission ID shouldn't be blank.");
+      
+      // Verify the result is stored by datastore.
+      String stored = storeImpl.loadResult(response.getSubId());
+      assertNotNull(stored, "Stored result shouldn't be null");
+      
+      assertEquals("2,3,5,7,11,13", stored);
+        
+    } finally {
+      // Shutdown channels and servers.
+      if (computeChannel != null) {
+        computeChannel.shutdownNow();
+      }
+      if (dsChannel != null) {
+        dsChannel.shutdownNow();
+      }
+      if (computeServer != null) {
+        computeServer.shutdownNow();
+      }
+      if (dataStoreServer != null) {
+        dataStoreServer.shutdownNow();
+      }
+    }
+  }
+
+}

--- a/test/GrpcLoadTest.java
+++ b/test/GrpcLoadTest.java
@@ -1,0 +1,122 @@
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.junit.jupiter.api.Test;
+
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Server;
+import io.grpc.ServerBuilder;
+import project.annotations.ComputeControllerAPI;
+import project.annotations.ComputeControllerAPIImplementation;
+import project.annotations.DataStoreComputeAPI;
+import project.annotations.DataStoreComputeAPIImplementation;
+import project.annotations.UserComputeAPI;
+import project.annotations.UserComputeAPIImplementation;
+import project.datastore.grpc.DataStoreGrpcService;
+import project.datastore.grpc.GrpcDataStoreComputeAPI;
+import project.rpc.usercompute.Delimiter;
+import project.rpc.usercompute.InputSource;
+import project.rpc.usercompute.OutputSource;
+import project.rpc.usercompute.SubmissionStatus;
+import project.rpc.usercompute.UserComputeAPIGrpc;
+import project.rpc.usercompute.UserSubResponse;
+import project.rpc.usercompute.UserSubmission;
+import project.usercompute.grpc.UserComputeGrpcService;
+
+public class GrpcLoadTest {
+
+  @Test
+  public void sustainedLoadTest() throws Exception {
+
+    Server dataStoreServer = null;
+    Server computeServer = null;
+    ManagedChannel dsChannel = null;
+    ManagedChannel computeChannel = null;
+    ExecutorService pool = null;
+
+    try {
+
+      DataStoreComputeAPI storeImpl = new DataStoreComputeAPIImplementation();
+
+      dataStoreServer = ServerBuilder.forPort(0).addService(new DataStoreGrpcService(storeImpl)).build().start();
+
+      int dataStorePort = dataStoreServer.getPort();
+      System.out.println("GrpcLoadTest -> Datastore server on port: " + dataStorePort);
+
+      dsChannel = ManagedChannelBuilder.forAddress("localhost", dataStorePort).usePlaintext().build();
+
+      DataStoreComputeAPI storeClient = new GrpcDataStoreComputeAPI(dsChannel);
+
+      ComputeControllerAPI core = new ComputeControllerAPIImplementation();
+      UserComputeAPI userApi = new UserComputeAPIImplementation(storeClient, core);
+
+      computeServer = ServerBuilder.forPort(0).addService(new UserComputeGrpcService(userApi)).build().start();
+
+      int computePort = computeServer.getPort();
+      System.out.println("GrpcLoadTest -> Compute server on port: " + computePort);
+
+      computeChannel = ManagedChannelBuilder.forAddress("localhost", computePort).usePlaintext().build();
+
+      UserComputeAPIGrpc.UserComputeAPIBlockingStub stub = UserComputeAPIGrpc.newBlockingStub(computeChannel);
+
+      // Pool of parallel tasks to stress the system for testing.
+      int numRequests = 200;
+      int parallelism = 8; // number of clients going at the same time.
+      pool = Executors.newFixedThreadPool(parallelism);
+      List<Callable<Void>> tasks = new ArrayList<>();
+
+      for (int i = 0; i < numRequests; i++) {
+        final int index = i;
+        tasks.add(() -> {
+          // Varies the input to test the cache and the performance of the compute.
+          int n = 16 + (index % 5) * 1000; // 16, 1016, 2016, etc.
+
+          UserSubmission request = UserSubmission.newBuilder()
+              .setInput(InputSource.newBuilder().setInputType("memory").setLocation(Integer.toString(n)).build())
+              .setOutput(OutputSource.newBuilder().setOutputType("stdout").setLocation("").build())
+              .setDelimiters(Delimiter.newBuilder().setComboDelimiter(",").setResultDelimiter(":").build()).build();
+
+          UserSubResponse response = stub.submit(request);
+
+          assertEquals(SubmissionStatus.SUB_STATUS_SUCCESS, response.getStatus(), "Submission succeeds for n = " + n);
+          assertNotNull(response.getSubId(), "Submission ID shouldn't be null.");
+          assertFalse(response.getSubId().isBlank(), "Submission ID shouldn't be blank.");
+          return null;
+        });
+      }
+
+      long start = System.nanoTime();
+      pool.invokeAll(tasks); // runs all the client calls.
+      long durationNs = System.nanoTime() - start;
+      double durationMs = durationNs / 1_000_000.0;
+
+      System.out.println("GrpcLoadTest -> Completed: " + numRequests + " gRPC submissions in: " + durationMs + " ms");
+
+    } finally {
+      // Shut down thread pool, channels and servers.
+      if (pool != null) {
+        pool.shutdownNow();
+      }
+      if (computeChannel != null) {
+        computeChannel.shutdownNow();
+      }
+      if (dsChannel != null) {
+        dsChannel.shutdownNow();
+      }
+      if (computeServer != null) {
+        computeServer.shutdownNow();
+      }
+      if (dataStoreServer != null) {
+        dataStoreServer.shutdownNow();
+      }
+    }
+  }
+}


### PR DESCRIPTION
This test starts datastore gRPC server with the datastore implementation. It then connects a channel to it and wraps it with the GrpcDataStoreComputeAPI. A compute gRPC server with the computecontrollerapiimplementation and the user compute implementation. Build a UserSubmission just like client. Calls .submit over gRPC. Assertions to ensure pipline is working as intended. This accomplishes thorough testing over the gRPC from end to end, verifying behavior works as intended.